### PR TITLE
Verbose & coloured output for pre-commit hook

### DIFF
--- a/submodule-hooks/pre-commit
+++ b/submodule-hooks/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/bash
+# define colors for use in output
+green='\033[0;32m'
+no_color='\033[0m'
+grey='\033[0;90m'
 
 # Check whether any submodule is about to be updated with the
 # commit. Ask the user for confirmation.
@@ -18,8 +22,15 @@ MOD_SUBMODULES=$(git diff --cached --name-only | grep -F "$SUBMODULES")
 # If no modified submodules, exit with status code 0, else prompt the
 # user and exit accordingly
 if [[ -n "$MOD_SUBMODULES" ]]; then
-    echo "The following modified submodules are about to be committed:"
-    echo "$MOD_SUBMODULES"
+    echo "Submodules to be committed:"
+    echo "  (use \"git reset HEAD <file>...\" to unstage)"
+    echo
+
+    for SUB in $MOD_SUBMODULES
+    do
+        echo -e "\t${green}modified:\t$SUB${no_color}"
+    done
+    echo
     echo -n "Continue with commit? [n] "
     read -n 1 reply </dev/tty
     echo

--- a/submodule-hooks/pre-commit
+++ b/submodule-hooks/pre-commit
@@ -8,7 +8,7 @@ grey='\033[0;90m'
 # commit. Ask the user for confirmation.
 # --Chaitanya Gupta
 
-echo "Checking if any submodules are being updated..."
+echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
 
 # Jump to the current project's root directory (the one containing
 # .git/)
@@ -31,15 +31,17 @@ if [[ -n "$MOD_SUBMODULES" ]]; then
         echo -e "\t${green}modified:\t$SUB${no_color}"
     done
     echo
-    echo -n "Continue with commit? [n] "
+    echo -n -e "Continue with commit? ${grey}[N|y]${no_color} "
     read -n 1 reply </dev/tty
     echo
     if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+        echo "Permitting submodules to be committed..."
         exit 0
     else
-        echo "Aborted commit."
+        echo "Aborting commit due to submodule update."
         exit 1
     fi
 else
+    echo "No submodules in commit, continuing..."
     exit 0
 fi


### PR DESCRIPTION
Hi @chaitanyagupta,

Thank you very much for making this repository available 😁  I found your pre-commit hook for checking submodules extremely useful & have borrowed very heavily from it.

The version I have uses quite different output.

In particular, I changed the initial output, that shows which submodules are about to be committed, to look exactly the same as `git status` looks.

![](https://puu.sh/vfzuT.png)

I also added a bunch of extra messaging, just to make it clear what's happening in every case.

This is *extremely* opinionated code, I have no expectations that you would merge it! I just wanted to say thank you and share what I did, just in case you like any of it.

Thanks again 👍